### PR TITLE
Display errors failed downloads but continue

### DIFF
--- a/src/ChocolateStore/PackageCacher.cs
+++ b/src/ChocolateStore/PackageCacher.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -58,27 +59,34 @@ namespace ChocolateStore
 
 		private string DownloadFile(string url, string destination)
 		{
+		    try
+		    {
+		        var request = WebRequest.Create(url);
+		        var response = request.GetResponse();
+		        var fileName = Path.GetFileName(response.ResponseUri.LocalPath);
+		        var filePath = Path.Combine(destination, fileName);
 
-			var request = WebRequest.Create(url);
-			var response = request.GetResponse();
-			var fileName = Path.GetFileName(response.ResponseUri.LocalPath);
-			var filePath = Path.Combine(destination, fileName);
+		        if (File.Exists(filePath))
+		        {
+		            SkippingFile(fileName);
+		        }
+		        else
+		        {
+		            DownloadingFile(fileName);
+		            using (var fs = File.Create(filePath))
+		            {
+		                response.GetResponseStream().CopyTo(fs);
+		            }
+		        }
 
-			if (File.Exists(filePath))
-			{
-				SkippingFile(fileName);
-			}
-			else
-			{
-				DownloadingFile(fileName);
-				using (var fs = File.Create(filePath))
-				{
-					response.GetResponseStream().CopyTo(fs);
-				}
-			}
-
-			return filePath;
-
+		        return filePath;
+		    }
+		    catch (Exception e)
+		    {
+		        Console.WriteLine("Failed to download: " + url);
+		        Console.WriteLine(e.Message);
+                return url;
+		    }
 		}
 
 	}


### PR DESCRIPTION
Report errors when downloading a file but continue to process the package.  I found that by setting it up this way I could diagnose any download problems a little easier.
