### PR TITLE
Support for cache directory

### DIFF
--- a/src/ChocolateStore/Arguments.cs
+++ b/src/ChocolateStore/Arguments.cs
@@ -2,7 +2,11 @@
 {
     class Arguments
     {
+		// where the packages are saved and referenced
         public string Directory { get; set; }
+		//where to download the package from
         public string Url { get; set; }
+		// where to save the packages
+		public string CacheDir { get; set; }
     }
 }

--- a/src/ChocolateStore/PackageCacher.cs
+++ b/src/ChocolateStore/PackageCacher.cs
@@ -101,3 +101,4 @@ namespace ChocolateStore
 
 	}
 }
+

--- a/src/ChocolateStore/Program.cs
+++ b/src/ChocolateStore/Program.cs
@@ -37,17 +37,26 @@ namespace ChocolateStore
 
             Arguments arguments = new Arguments();
 
-            if (args.Length != 2)
-            {
-                WriteError("USAGE: ChocolateStore <directory> <url>");
+            if (args.Length != 2 && args.Length != 3 )
+			{
+                WriteError("USAGE: ChocolateStore <directory> <url> <optional: store directory>");
                 return null;
             }
 
             arguments.Directory = args[0];
 
-            if (!Directory.Exists(arguments.Directory))
+			if (args.Length == 3)
+			{
+				arguments.CacheDir = args[2];
+			}
+			else
+			{
+				arguments.CacheDir = arguments.Directory;
+			}
+
+			if (!Directory.Exists(arguments.CacheDir))
             {
-                WriteError("Directory '{0}' does not exist.", arguments.Directory);
+				WriteError("Directory '{0}' does not exist.", arguments.CacheDir);
                 return null;
             }
 

--- a/src/ChocolateStore/Program.cs
+++ b/src/ChocolateStore/Program.cs
@@ -21,7 +21,7 @@ namespace ChocolateStore
 
                 if (arguments != null)
                 {
-                    cacher.CachePackage(arguments.Directory, arguments.Url);
+                    cacher.CachePackage(arguments.Directory, arguments.Url, arguments.CacheDir);
                 }
 
             }


### PR DESCRIPTION
Hello,

I've used with success your Project, for downloading Chocolatey Packages.
My problem was that I have some computers on a different network wihtout an internet connection, so I had to copy the download folder from one server to another. Chocolatey was unable to upgrade the packages since the PATH in the .ps1 scripts was not right anymore.

This is why I added a third (optional) parameter to specify a "cache directory", where ChocolateStore is going to download all the files, but the path used in the .ps1 files is still going to be the directory path.
