### PR TITLE
feat: accept package-name (auto-resolve URL)

### DIFF
--- a/src/ChocolateStore/Arguments.cs
+++ b/src/ChocolateStore/Arguments.cs
@@ -4,5 +4,6 @@
     {
         public string Directory { get; set; }
         public string Url { get; set; }
+        public string PackageName { get; set; }
     }
 }

--- a/src/ChocolateStore/ChocolateStore.csproj
+++ b/src/ChocolateStore/ChocolateStore.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HtmlAgilityPack, Version=1.6.17.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.6.17\lib\Net40-client\HtmlAgilityPack.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Ionic.Zip">
       <HintPath>..\..\packages\DotNetZip.1.9.3\lib\net20\Ionic.Zip.dll</HintPath>
     </Reference>

--- a/src/ChocolateStore/Program.cs
+++ b/src/ChocolateStore/Program.cs
@@ -21,7 +21,7 @@ namespace ChocolateStore
 
                 if (arguments != null)
                 {
-                    cacher.CachePackage(arguments.Directory, arguments.Url);
+                    cacher.CachePackage(arguments);
                 }
 
             }
@@ -51,12 +51,12 @@ namespace ChocolateStore
                 return null;
             }
 
-            arguments.Url = args[1];
-
-            if (!Uri.IsWellFormedUriString(arguments.Url, UriKind.Absolute))
+            if (Uri.IsWellFormedUriString(args[1], UriKind.Absolute))
             {
-                WriteError("URL '{0}' is invalid.", arguments.Url);
-                return null;
+                arguments.Url = args[1];
+            } else
+            {
+                arguments.PackageName = args[1];
             }
 
             return arguments;

--- a/src/ChocolateStore/packages.config
+++ b/src/ChocolateStore/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNetZip" version="1.9.3" targetFramework="net40-Client" />
+  <package id="HtmlAgilityPack" version="1.6.17" targetFramework="net40-client" />
 </packages>


### PR DESCRIPTION
Hi again, here's another patch that lets you specify package-name and it auto-resolves the package-url. It uses [html-agility-pack][1] which I hope is the best way to do parsing (again, first time in c#). I'm also planning to use it to solve the fetching-dependency problem later. 

[1]: http://html-agility-pack.net/?z=codeplex